### PR TITLE
Add button on homepage to link to fundamentals tutorials

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -53,7 +53,7 @@ launch_buttons:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/uwhackweek/jupyterbook-template # Online location of your book
+  url: https://github.com/BOAT-ocean-acoustics/boat-ocean-acoustics.github.io # Online location of your book
   path_to_book: book  # Optional path to your book, relative to the repository root
   branch: main  # Which branch of the repository should be used when creating links (optional)
 

--- a/cookiecutter.yaml
+++ b/cookiecutter.yaml
@@ -15,9 +15,9 @@ banner:
     new_window: true
     style: btn-primary
   - url: https://boat-fundamentals.readthedocs.io/en/latest/landing.html
-    title: Fundamentals tutorials
+    title: 'Tutorials: Fundamentals'
     new_window: true
-    style: btn-warning
+    style: btn-success
   image: assets/images/carson_laptop.jpg
 # The opening session of the event with UTC offset
 event_countdown: "2024-08-07T08:30:00-07:00"

--- a/cookiecutter.yaml
+++ b/cookiecutter.yaml
@@ -12,7 +12,12 @@ banner:
   links:
   - url: intro.html
     title: BOAT Program
-    new_window: false
+    new_window: true
+    style: btn-primary
+  - url: https://boat-fundamentals.readthedocs.io/en/latest/landing.html
+    title: Fundamentals tutorials
+    new_window: true
+    style: btn-warning
   image: assets/images/carson_laptop.jpg
 # The opening session of the event with UTC offset
 event_countdown: "2024-08-07T08:30:00-07:00"

--- a/{{ cookiecutter.repo_directory }}/index.html
+++ b/{{ cookiecutter.repo_directory }}/index.html
@@ -121,7 +121,7 @@
             {%- if cookiecutter.banner.links %}
             <div class="hero-cta">
                 {%- for link in cookiecutter.banner.links %}
-                <a class="btn btn-primary btn-lg m-2"
+                <a class="btn {{ link.style }} btn-lg m-2"
                    href="{{ link.url }}"
                    {{ 'target="_blank"' if link.new_window == 'True' else '' }}
                 >


### PR DESCRIPTION
Tracing info from below:
- https://github.com/PACEHackWeek/pace-2025/commit/a1b5eb5ba592c20794a811721b6102e3018641e9
- https://github.com/PACEHackWeek/pace-2025/blob/main/cookiecutter.yaml
- https://github.com/PACEHackWeek/pace-2025/blame/main/%7B%7B%20cookiecutter.repo_directory%20%7D%7D/index.html
- https://pacehackweek.github.io/pace-2024/

Also updated the link to repository from Jupyter Book.